### PR TITLE
adaptation.length may be 0

### DIFF
--- a/src/mpegts.cpp
+++ b/src/mpegts.cpp
@@ -15,7 +15,7 @@ MPEGTS::MPEGTS(DataPacket * mpegts_packet) {
     
     this->adaptation.length     = this->header.adapt_control ? ts_packet[4] : 0;
 
-    if(this->header.adapt_control) {
+    if(this->header.adapt_control && this->adaptation.length) {
         this->adaptation.discontinuity  = ts_packet[5] >> 7;
         this->adaptation.random_access  = ts_packet[5] << 1 >> 7;
         this->adaptation.es_priority    = ts_packet[5] << 2 >> 7;


### PR DESCRIPTION
reference: ISO13818 2.4.3.5

> The adaptation_field_length is an 8-bit field specifying the number of bytes in the adaptation_field immediately following the adaptation_field_length. The value 0 is for inserting a single stuffing byte in a Transport Stream packet.
